### PR TITLE
remove bad node engine spec from package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -7,9 +7,6 @@
   },
   "keywords": [],
   "license": "Apache-2.0",
-  "engines": {
-    "node": "~14.17"
-  },
   "scripts": {
     "bootstrap": "lerna link && lerna bootstrap",
     "build": "lerna run build",


### PR DESCRIPTION
This node engine version requirement is low and unhelpful.  I'm successfully working with @lts (16.x) and it's fine.